### PR TITLE
Fix wrong font in macOS inline predictions

### DIFF
--- a/Beat/Text Editor View/BeatTextView.m
+++ b/Beat/Text Editor View/BeatTextView.m
@@ -718,7 +718,31 @@ double clamp(double d, double min, double max)
 
 -(NSString *)text { return self.string; }
 - (void)setText:(NSString *)text { self.string = text; }
-@synthesize typingAttributes;
+@synthesize typingAttributes = _typingAttributes;
+
+/// This property shadows the native `NSTextView` typing attributes, which are also used by the system to draw inline predictions (macOS 14+).
+/// If no font is set, predicted text will be drawn using the system font instead of editor font, so we'll make sure the attributes always contain one.
+- (NSDictionary<NSAttributedStringKey, id>*)typingAttributes
+{
+	NSDictionary* attributes = _typingAttributes;
+	if (attributes[NSFontAttributeName] != nil) return attributes;
+
+	NSMutableDictionary* attributesWithFont = (attributes != nil) ? attributes.mutableCopy : NSMutableDictionary.new;
+	attributesWithFont[NSFontAttributeName] = [self fontAtCaret];
+	return attributesWithFont;
+}
+
+/// Returns the font at current caret position, falling back to editor default.
+- (NSFont*)fontAtCaret
+{
+	NSTextStorage* textStorage = self.textStorage;
+	if (textStorage.length > 0) {
+		NSUInteger location = MIN(self.selectedRange.location, textStorage.length - 1);
+		NSFont* font = [textStorage attribute:NSFontAttributeName atIndex:location effectiveRange:nil];
+		if (font != nil) return font;
+	}
+	return _editorDelegate.fonts.regular;
+}
 
 
 #pragma mark - Caret

--- a/Frameworks/BeatCore/BeatCore/Editor Formatting/BeatEditorFormatting.m
+++ b/Frameworks/BeatCore/BeatCore/Editor Formatting/BeatEditorFormatting.m
@@ -438,7 +438,9 @@ NSString* const BeatRepresentedLineKey = @"representedLine";
 		}
         
 		if (!alreadyEditing) [textStorage endEditing];
-        
+
+        // Typing attributes are also used to draw system inline predictions, so they should always contain the correct font
+        if (attributes[NSFontAttributeName] == nil) attributes[NSFontAttributeName] = [self fontFamilyForLine:line];
         [_delegate.getTextView setTypingAttributes:attributes];
         
         self.lineBeingFormatted = nil;
@@ -535,7 +537,10 @@ NSString* const BeatRepresentedLineKey = @"representedLine";
 	[self setTextColorFor:line];
     
     if (!alreadyEditing) [textStorage endEditing];
-    if (shouldSetTypingAttributes) [_delegate.getTextView setTypingAttributes:attributes];
+    if (shouldSetTypingAttributes) {
+        if (attributes[NSFontAttributeName] == nil) attributes[NSFontAttributeName] = [self fontFamilyForLine:line];
+        [_delegate.getTextView setTypingAttributes:attributes];
+    }
     
     self.lineBeingFormatted = nil;
     _formatting = false;


### PR DESCRIPTION
BeatTextView shadows the native NSTextView typingAttributes with a plain ivar, and the attributes set by BeatEditorFormatting could lack NSFontAttributeName (empty lines / end of document). Since macOS 14 draws inline predictive text using typing attributes, predictions were rendered with the system font instead of the editor font.

The typingAttributes getter now falls back to the font at the caret (or the default editor font), and BeatEditorFormatting always includes the line's font when setting typing attributes.