### PR TITLE
Fix adding a synopsis to the last scene

### DIFF
--- a/Beat iOS/User Interface Views/Card View/Index Card View.beatPlugin
+++ b/Beat iOS/User Interface Views/Card View/Index Card View.beatPlugin
@@ -273,7 +273,7 @@ Beat.custom = {
 		let suitableIndex = index
 		
 		// Find a good place to add our synopsis to
-		for (let i=index+1; i++; i<lines.length) {
+		for (let i=index+1; i < lines.length; i++) {
 			let line = lines[i]
 			if (line.type == Beat.type.empty) continue;
 			


### PR DESCRIPTION
The loop in addSynopsis had its condition and increment swapped, so it ran past the end of the lines array; reading line.type on the undefined element logged a console error and the synopsis wasn't kept.