### PR TITLE
Forcing character lines to be uppercase

### DIFF
--- a/Frameworks/BeatCore/BeatCore/Styles/Style definitions/Screenplay-editor-iOS.beatCSS
+++ b/Frameworks/BeatCore/BeatCore/Styles/Style definitions/Screenplay-editor-iOS.beatCSS
@@ -48,6 +48,8 @@ character {
     width-us: 40ch;
     
     margin-left: 9ch;
+    
+    uppercase: true;
 }
 
 parenthetical {

--- a/Frameworks/BeatCore/BeatCore/Styles/Style definitions/Screenplay-editor.beatCSS
+++ b/Frameworks/BeatCore/BeatCore/Styles/Style definitions/Screenplay-editor.beatCSS
@@ -54,6 +54,8 @@ character {
     width-us: 40ch;
     
     margin-left: 20ch;
+    
+    uppercase: true;
 }
 
 parenthetical {

--- a/Frameworks/BeatCore/BeatCore/Styles/Style definitions/Screenplay.beatCSS
+++ b/Frameworks/BeatCore/BeatCore/Styles/Style definitions/Screenplay.beatCSS
@@ -100,6 +100,8 @@ character {
     margin-top: 1l;
     
     trim: true;
+    
+    uppercase: true;
 }
 
 parenthetical {


### PR DESCRIPTION
I noticed that if I used a macro for a character name then it didn't get properly uppercased when it was used in a character line. For example:

```
                @{{Nephew}}
          Hello Uncle!
```
Became:
```
                Billy
          Hello Uncle!
```
When I would have expected:
```
                BILLY
          Hello Uncle!
```